### PR TITLE
Update to add prefix configuration options like statsd

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ statsdpy sample config with default options:
     #calculate the XXth percentile
     percent_threshold = 90
 
+    # Override the key prefixes and suffixes - see https://github.com/etsy/statsd/blob/master/docs/namespacing.md
+    legacy_namespace = False
+    global_prefix = stats
+    prefix_counter = counters
+    prefix_timer = timers
+    prefix_gauge = gauges
+
  - Edit the config file appropriately for your environment
  - Start the service: `statsdpy-server start --conf=/path/to/your.conf`
  - Fire some udp counter, timer, or gauge events at statsdpy

--- a/etc/statsdpy/statsdpy.conf-sample
+++ b/etc/statsdpy/statsdpy.conf-sample
@@ -22,3 +22,10 @@ debug = no
 flush_interval = 10
 #calculate the XXth percentile
 percent_threshold = 90
+
+# Override the key prefixes and suffixes - see https://github.com/etsy/statsd/blob/master/docs/namespacing.md
+legacy_namespace = False
+global_prefix = stats
+prefix_counter = counters
+prefix_timer = timers
+prefix_gauge = gauges


### PR DESCRIPTION
- Add the same options but underscore delimited instead of camelCase, where supported
  - legacy_namespace
  - global_prefix
  - prefix_counter
  - prefix_timer
  - prefix_gauge
- Default to new namespace structure as defined by https://github.com/etsy/statsd/blob/master/docs/namespacing.md
- Minor refactors to minimize code or reduce operations
- Add a few debug checks for print output
