### PR TITLE
Resilliency changes/fixes, and clear timers fix

### DIFF
--- a/statsdpy/__init__.py
+++ b/statsdpy/__init__.py
@@ -2,7 +2,7 @@ import gettext
 
 
 #: Version information (major, minor, revision[, 'dev']).
-version_info = (0, 0, 11)
+version_info = (0, 0, 12)
 #: Version string 'major.minor.revision'.
 version = __version__ = ".".join(map(str, version_info))
 gettext.install('statsdpy')


### PR DESCRIPTION
- Fixes a bug introduced in 7f502e81c71db748c636795b86b961cb048bfdfc
  that failed to clear timer counters when metrics where reported via
  the plain graphite protocol.
- Makes sure eventlet timeouts during reporting to graphite are actually
  caught, retried, and that the socket is cleaned up.
- wrap decode_recv and stats flush in bare excepts to let both
  continue on incase of unexpected errors that didn't inherit from
  Exception.

should help trackdown or fix issue #6
